### PR TITLE
Improve robustness and add API key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,9 @@ jobs:
       - name: Test with pytest
         run: |
           pytest --cov=audiobookz_organizer --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          threshold: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## 1.1.0
+## Unreleased
+- Added Google Books API key support via `--api-key` flag
+- Improved dry run accuracy and file operation error handling
+- Hardened Google Books API response parsing
+- Enhanced docs structure and CI coverage enforcement
+
+## 1.0.0
 - Read metadata from audio files using mutagen
 - Concurrent folder processing
 - Optional metadata fetch from Google Books

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ AudioBookzOrganizer is a Python utility that renames and organizes your audioboo
 
 ## Metadata Sources
 
-By default the organizer reads tags from the audio files themselves. If tags are missing, it falls back to parsing the folder name. Passing ``--fetch-metadata`` enables online lookups through the Google Books API for genre and publication year.
+By default the organizer reads tags from the audio files themselves. If tags are missing, it falls back to parsing the folder name. Passing ``--fetch-metadata`` enables online lookups through the Google Books API for genre and publication year. Using an API key with ``--api-key`` greatly increases the allowed request quota.
 
 ## Performance
 
@@ -23,7 +23,9 @@ Folders are processed concurrently using a thread pool so large libraries are sc
 The organizer can create nested folder hierarchies using any combination of available metadata fields. For example:
 
 ```bash
-organize-audiobooks -i ./in -o ./out --folder-structure genre,author --fetch-metadata --commit
+organize-audiobooks -i ./in -o ./out \
+  --folder-structure genre,author \
+  --fetch-metadata --api-key YOUR_KEY --commit
 ```
 
 

--- a/audiobookz_organizer/cli.py
+++ b/audiobookz_organizer/cli.py
@@ -31,6 +31,7 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Fetch additional metadata from online sources",
     )
+    parser.add_argument("--api-key", help="Google Books API key for metadata fetching")
     return parser.parse_args()
 
 
@@ -52,6 +53,7 @@ def main() -> None:
         structure=structure,
         commit=args.commit,
         fetch_metadata=args.fetch_metadata,
+        api_key=args.api_key,
     )
 
 

--- a/audiobookz_organizer/core.py
+++ b/audiobookz_organizer/core.py
@@ -11,6 +11,11 @@ from .models import Audiobook
 from .fetcher import fetch_book_details
 
 
+class AudioBookProcessError(Exception):
+    """Raised when an expected error occurs during audiobook processing."""
+    pass
+
+
 def organize_audiobooks(
     audiobook_dir: Path,
     output_dir: Path,
@@ -18,6 +23,7 @@ def organize_audiobooks(
     structure: list[str],
     commit: bool,
     fetch_metadata: bool = False,
+    api_key: str | None = None,
 ) -> None:
     """Scan ``audiobook_dir`` and organize audiobook folders.
 
@@ -33,6 +39,10 @@ def organize_audiobooks(
         Folder hierarchy expressed as a list of audiobook attributes.
     commit: bool
         If ``True``, perform changes; otherwise print actions only.
+    fetch_metadata: bool
+        When ``True``, attempt to fetch genre and year via the Google Books API.
+    api_key: str | None
+        Google Books API key to use when fetching metadata.
     """
 
     print("\nScanning for folders to rename and organize...")
@@ -50,6 +60,7 @@ def organize_audiobooks(
                 structure,
                 commit,
                 fetch_metadata,
+                api_key,
             ): folder
             for folder in folders_to_process
         }
@@ -62,8 +73,8 @@ def organize_audiobooks(
                     print(message)
                     if "MOVED" in message or "DRY-RUN" in message:
                         processed_count += 1
-            except Exception as exc:
-                print(f"ERROR: An exception occurred while processing {folder.name}: {exc}")
+            except AudioBookProcessError as exc:
+                print(str(exc))
 
     msg = "Operation complete" if commit else "Dry run complete"
     print(f"\n{msg}. {processed_count} folders processed.")
@@ -76,6 +87,7 @@ def _process_folder(
     structure: list[str],
     commit: bool,
     fetch_metadata: bool,
+    api_key: str | None,
 ) -> str:
     metadata = extract_metadata_from_folder(folder_path)
     audiobook: Audiobook | None = None
@@ -93,22 +105,22 @@ def _process_folder(
         return f"SKIPPED: {folder_path.name} (Could not determine metadata)"
 
     if fetch_metadata:
-        details = fetch_book_details(audiobook.title, audiobook.author)
+        details = fetch_book_details(audiobook.title, audiobook.author, api_key)
         if details:
             audiobook.genre = details.get("genre", audiobook.genre)
             audiobook.year = details.get("year", audiobook.year)
 
     target_path = audiobook.get_target_path(output_dir, naming, structure)
 
-    if not commit:
-        return f"DRY-RUN: Would move {folder_path} -> {target_path}"
-
     if target_path.exists():
         return f"SKIPPED: {folder_path.name} (Target exists)"
+
+    if not commit:
+        return f"DRY-RUN: Would move {folder_path} -> {target_path}"
 
     try:
         target_path.parent.mkdir(parents=True, exist_ok=True)
         folder_path.rename(target_path)
         return f"MOVED: {folder_path} -> {target_path}"
     except OSError as e:
-        return f"ERROR: Failed to move {folder_path}: {e}"
+        raise AudioBookProcessError(f"ERROR: Failed to move {folder_path}: {e}")

--- a/audiobookz_organizer/fetcher.py
+++ b/audiobookz_organizer/fetcher.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import requests
 
 
-def fetch_book_details(title: str, author: str) -> dict | None:
+def fetch_book_details(title: str, author: str, api_key: str | None = None) -> dict | None:
     """Retrieve metadata from the Google Books API for the given book."""
     params = {"q": f"intitle:{title}+inauthor:{author}"}
+    if api_key:
+        params["key"] = api_key
     try:
         response = requests.get("https://www.googleapis.com/books/v1/volumes", params=params, timeout=10)
     except requests.RequestException:
@@ -16,8 +18,19 @@ def fetch_book_details(title: str, author: str) -> dict | None:
     data = response.json()
     if data.get("totalItems", 0) == 0:
         return None
-    info = data["items"][0]["volumeInfo"]
+
+    items = data.get("items")
+    if not items:
+        return None
+
+    volume_info = items[0].get("volumeInfo", {})
+    if not volume_info:
+        return None
+
+    categories = volume_info.get("categories", ["Unknown Genre"])
+    published_date = volume_info.get("publishedDate", "0000")
+
     return {
-        "genre": info.get("categories", ["Unknown Genre"])[0],
-        "year": info.get("publishedDate", "0000").split("-")[0],
+        "genre": categories[0],
+        "year": published_date.split("-")[0],
     }

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,5 @@
+CLI Module
+==========
+
+.. automodule:: audiobookz_organizer.cli
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,6 @@
 project = 'AudioBookzOrganizer'
+author = 'Bryan C'
+release = '1.0.0'
 extensions = ['sphinx.ext.autodoc']
 master_doc = 'index'
 html_theme = 'alabaster'

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -1,0 +1,5 @@
+Core Module
+===========
+
+.. automodule:: audiobookz_organizer.core
+   :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,9 @@
 AudioBookzOrganizer Documentation
 ================================
 
-.. automodule:: audiobookz_organizer
-    :members:
+.. toctree::
+   :maxdepth: 2
+
+   core
+   cli
+   models

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,0 +1,5 @@
+Models Module
+=============
+
+.. automodule:: audiobookz_organizer.models
+   :members:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,4 @@ def test_parse_args_defaults(monkeypatch):
     assert args.folder_structure == ''
     assert args.commit is False
     assert args.fetch_metadata is False
+    assert args.api_key is None

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -21,3 +21,21 @@ def test_fetch_book_details_success(mocker):
 
     info = fetch_book_details('Title', 'Author')
     assert info == {'genre': 'Fiction', 'year': '2001'}
+
+
+def test_fetch_book_details_request_exception(mocker):
+    mocker.patch.object(requests, 'get', side_effect=requests.RequestException)
+    assert fetch_book_details('Title', 'Author') is None
+
+
+def test_fetch_book_details_non_200(mocker):
+    mock_resp = Mock(status_code=500)
+    mocker.patch.object(requests, 'get', return_value=mock_resp)
+    assert fetch_book_details('Title', 'Author') is None
+
+
+def test_fetch_book_details_no_items(mocker):
+    mock_resp = Mock(status_code=200)
+    mock_resp.json.return_value = {'totalItems': 0}
+    mocker.patch.object(requests, 'get', return_value=mock_resp)
+    assert fetch_book_details('Title', 'Author') is None

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -13,6 +13,8 @@ from audiobookz_organizer.parser import parse_folder
         ("Some Title - Some Author", "Some Author", "Some Title"),
         ("J.R.R. Tolkien - The Hobbit", "J.R.R. Tolkien", "The Hobbit"),
         ("The Girl Who Played with Fire - Stieg Larsson", "Stieg Larsson", "The Girl Who Played with Fire"),
+        ("A Book - With a Hyphen - Some Author", "Some Author", "A Book - With a Hyphen"),
+        ("Not an Author - This title - ends", "ends", "Not an Author - This title"),
     ],
 )
 def test_parse_folder_success(foldername, expected_author, expected_title):


### PR DESCRIPTION
## Summary
- handle target existence before dry-run to avoid misleading output
- wrap file move errors in custom `AudioBookProcessError`
- harden Google Books API parsing and accept optional API key
- expose `--api-key` CLI option
- restructure docs and update changelog
- expand tests for failure cases
- enforce coverage threshold in CI

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mutagen')*

------
https://chatgpt.com/codex/tasks/task_e_68569b7d3c44832d9be522623427bbff